### PR TITLE
more versions of erlang in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,9 @@ language: erlang
 otp_release:
    - R16B03
    - R15B03
+   - R16B03-1
+   - R16B02
+   - R16B01
+   - 17.0
+   - 17.1
+   - 17.3


### PR DESCRIPTION
Support in Travis-CI for versions R16.x and R17 o Erlang