### PR TITLE
In the eunit hint use binding instead of equals-to

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -127,7 +127,7 @@ and have a function added called `check/0` which runs `triq:check/1` on all the 
 A handy addition that I use is to also add an `eunit` test, which tests it:
 
 ```erlang
-property_test() -> true == check().
+property_test() -> true = check().
 ```
 Which can then automatically be run using your favourite `eunit` runner.
 


### PR DESCRIPTION
An equality check doesn't result in an eunit test failure, while a bad match does.